### PR TITLE
Standardize remotes codes

### DIFF
--- a/documentation/default_keys.jsonc
+++ b/documentation/default_keys.jsonc
@@ -1,0 +1,66 @@
+{
+    /* Power Related Buttons */
+    "power": "power toggle button",
+
+    /* Mode Buttons */
+    "pc": "macro0/PC button (e.g. switch modes)",
+    "tv": "macro1/TV button (e.g. switch modes)",
+    "tv2": "macro2/TV2 button (e.g. switch modes)",
+    "vcr": "macro3/VCR button (e.g. switch modes)",
+    "vcr2": "macro4/VCR2 button (e.g. switch modes)",
+    "sat": "macro5/SAT button (e.g. switch modes)",
+    "sat2": "macro6/SAT2 button (e.g. switch modes)",
+    "cd": "macro7/CD button (e.g. switch modes)",
+    "tape": "macro8/TAPE button (e.g. switch modes)",
+    "radio": "macro9/RADIO button (e.g. switch modes)",
+
+    /* Media Buttons */
+    "pause": "pause button",
+    "play": "play button",
+    "fastforward": "fast forward button",
+    "rewind": "rewind button",
+    "record": "record button",
+    "stop": "stop button",
+
+    /* Color Buttons */
+    "red": "red button",
+    "green": "green button",
+    "yellow": "yellow button",
+    "blue": "blue button",
+
+    /* Misc Buttons */
+    "pvr": "PVR/DVR button",
+    "epg": "guide/Electronic Programming Guide button",
+    "info": "info button",
+    "exit": "exit/Back button",
+    "menu": "menu button",
+    "channelup": "channel up button",
+    "channeldown": "channel down button",
+    "back": "back button",
+    "minus": "minus button",
+    "enter": "enter button",
+
+    /* Volume Buttons */
+    "mute": "mute button",
+    "volumedown": "volume down button",
+    "volumeup": "volume up button",
+
+    /* Navigation Buttons */
+    "up": "up button",
+    "left": "left button",
+    "right": "right button",
+    "down": "down button",
+    "ok": "ok button (found at the center of the arrow pad)",
+
+    /* Number Buttons */
+    "1": "1 button",
+    "2": "2 button",
+    "3": "3 button",
+    "4": "4 button",
+    "5": "5 button",
+    "6": "6 button",
+    "7": "7 button",
+    "8": "8 button",
+    "9": "9 button",
+    "0": "0 button"
+}

--- a/scripts/capture_keypress_value.py
+++ b/scripts/capture_keypress_value.py
@@ -1,0 +1,17 @@
+import asyncio
+
+from evdev import InputDevice, categorize, ecodes
+
+dev = InputDevice("/dev/input/event9")
+
+# prints the button press val in hex
+async def helper(dev):
+    async for ev in dev.async_read_loop():
+        # 0 == down; 1 == up; 2 == hold
+        if ev.value > 2:
+            hex_value = hex(ev.value)
+            print(hex_value)
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(helper(dev))

--- a/scripts/generate_keymap.py
+++ b/scripts/generate_keymap.py
@@ -1,0 +1,24 @@
+import struct
+from jsonc_parser.parser import JsoncParser
+
+f = open("/dev/input/event0", "rb")
+# Open the file in the read-binary mode
+
+file_path = "../documentation/default_keys.jsonc"
+buttons = JsoncParser.parse_file(file_path)
+
+for button in buttons:
+    print("Press button to map to the %s or hit enter to skip" % buttons[button])
+
+    # Capture the button down
+    data = f.read(24)
+
+    # only capture the hex value of the keypres
+    key_value = "KEY_%s" % (hex(struct.unpack("4IHHI", data)[3])[2:])
+
+    # Discard the SYNs and button up presses
+    f.read(24)  # Button down SYN
+    f.read(24)  # Button up
+    f.read(24)  # Button up SYN
+
+    print(key_value)


### PR DESCRIPTION
This PR will allow new remotes to be mapped to a common set of keys.  
This will allow the json files to use the key names instead of the scancode, making it easier to share configurations.  

The identified keys are just a suggestion but uses the Harmony Smart Control as a baseline and adds a set of macro keys that can be mapped to different modes.  See https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h for KEY_* entries. 

Current progress:
 * suggested keys have been identified
 * script can read from a given device and return the KEY_XXXXX

Next steps:
 * list available HID devices (e.g. /dev/input/event*) and allow user to select their new remote interface
 * allow keys to be skipped if not present on the remote
 * write hwdb configuration